### PR TITLE
PDB template needs matchLabels.

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -7,9 +7,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.13.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.27.0
+appVersion: v0.27.0

--- a/helm/templates/pod_disruption_budget.yaml
+++ b/helm/templates/pod_disruption_budget.yaml
@@ -8,5 +8,6 @@ metadata:
 spec:
 {{ .Values.podDisruptionBudget | toYaml | nindent 2 }}
   selector:
-    {{- include "superblocks-agent.selectorLabels" . | nindent 4 }}
+    matchLabels:
+      {{- include "superblocks-agent.selectorLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
Added matchLabels for pod_disruption_budget template.
Changed appVersion to include the "v" or else the default won't be able to correctly pull the image either