### PR TITLE
Add agent environment configuration to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ The agent application can be configured via the use of several environment varia
 | Name                                            | Description                                                                                                                                                                                              | Required | Default                       |
 | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------- |
 | SUPERBLOCKS_AGENT_KEY                           | Secret key used by Superblocks Cloud to authorize the agent                                                                                                                                              | Yes      | n/a                           |
-| SUPERBLOCKS_AGENT_HOST_URL                      | URL used by end-users to access the agent. This variable should be overridden for non-localhost deployments                                                                                              | No       | http://localhost:8020/agent   |
+| SUPERBLOCKS_AGENT_HOST_URL                      | URL used by end-users to access the agent. This variable should be overridden for non-localhost deployments                                                                                              | Yes      | http://localhost:8020/agent   |
+| SUPERBLOCKS_AGENT_ENVIRONMENT                   | Config specifying which [environment-specific workloads][env_support] can be run against this agent; one of '\*' (supports all environments), 'staging', and 'production'                                | No       | \*                            |
 | SUPERBLOCKS_AGENT_PORT                          | HTTP port that the agent listens on                                                                                                                                                                      | No       | 8020                          |
-| SUPERBLOCKS_AGENT_ENV_VARS_JSON                 | Environment variables (JSON format) to be passed into code execution. For example: `{ 'MY_ENV_VAR': "some value", 'MY_OTHER_ENV_VAR': "another value" }`. Access the vars using `Env.MY_ENV_VAR` in code | No       |                               |
+| SUPERBLOCKS_AGENT_ENV_VARS_JSON                 | Environment variables (JSON format) to be passed into code execution. For example: `{ 'MY_ENV_VAR': "some value", 'MY_OTHER_ENV_VAR': "another value" }`. Access the vars using `Env.MY_ENV_VAR` in code | No       | {}                            |
 | SUPERBLOCKS_AGENT_EXECUTION_JS_TIMEOUT_MS       | Timeout (in ms) for a given Javascript API Step execution                                                                                                                                                | No       | 30000                         |
 | SUPERBLOCKS_AGENT_EXECUTION_PYTHON_TIMEOUT_MS   | Timeout (in ms) for a given Python API Step execution                                                                                                                                                    | No       | 30000                         |
 | SUPERBLOCKS_AGENT_LOG_LEVEL                     | Log level; one of 'fatal', 'error', 'warn', 'info', 'debug', 'trace' or 'silent'                                                                                                                         | No       | info                          |
@@ -22,6 +23,8 @@ The agent application can be configured via the use of several environment varia
 | SUPERBLOCKS_AGENT_DATADOG_CONNECT_TAGS          | Array (comma-separated) of tags to be added to Datadog histograms                                                                                                                                        | No       | app:superblocks               |
 | SUPERBLOCKS_AGENT_SERVER_URL                    | Superblocks Cloud host that the agent will make fetch calls to                                                                                                                                           | No       | https://app.superblockshq.com |
 | SUPERBLOCKS_AGENT_JSON_PARSE_LIMIT              | Express request body limit (in mb)                                                                                                                                                                       | No       | 50mb                          |
+
+[env_support]: https://docs.superblocks.com/superblocks/software-development-lifecycle/staging-and-prod-environments
 
 ## Deployment
 
@@ -41,6 +44,7 @@ To deploy the Superblocks agent using docker, run the following command:
 docker run --name superblocks-agent \
   --env SUPERBLOCKS_AGENT_KEY=<agent-key> \
   --env SUPERBLOCKS_AGENT_HOST_URL=<agent-host>/agent \
+  --env SUPERBLOCKS_AGENT_ENVIRONMENT=<"*"|"staging"|"production"> \
   --publish <agent-port>:8020 \
   --rm ghcr.io/superblocksteam/agent:<tag>
 ```
@@ -61,6 +65,7 @@ services:
     environment:
       - SUPERBLOCKS_AGENT_KEY=<agent-key>
       - SUPERBLOCKS_AGENT_HOST_URL=<agent-host>/agent
+      - SUPERBLOCKS_AGENT_ENVIRONMENT=<"*"|"staging"|"production">
     ports:
       - '<agent-port>:<agent-port>'
 ```
@@ -88,7 +93,8 @@ The `values.yaml` should be a locally kept yaml with the user's environment spec
 ```yaml
 superblocks:
   agentKey: <agent-key> # obtained during agent onboarding
-  agentHostUrl: "http[s]://<agent-host[:port]>/agent"
+  agentHostUrl: 'http[s]://<agent-host[:port]>/agent'
+  agentEnvironment: <"*"|"staging"|"production">
 ```
 
 ## Requests

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -7,9 +7,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.0
+version: 0.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.28.0
+appVersion: v0.30.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.16.0
+version: 0.17.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,10 +6,9 @@
 # the https://app.superblockshq.com/opas Superblocks UI page
 # Ref: https://docs.superblockshq.com/superblocks/security-and-permissions/on-premise-agent-overview/deployment
 superblocks: {}
-#   agentId: ""
 #   agentKey: ""
 #   agentHostUrl: "http[s]://<agent-host[:port]>/agent"
-#   agentEnvironment: [staging|production|*]
+#   agentEnvironment: <"*"|"staging"|"production">
 #   agentKeyExistingSecret: "<my-superblocks-agent-key-secret>", optional. Secret is created for you if not specified.
 #
 # Existing agentKey secret must contain the value:
@@ -62,10 +61,10 @@ ingress:
   #       - chart-example.local
 
 resources:
-# Please adjust these values as needed depending on
-# your workloads. Allotting less than this could
-# potentially cause your agents to crash from
-# Out Of Memory errors.
+  # Please adjust these values as needed depending on
+  # your workloads. Allotting less than this could
+  # potentially cause your agents to crash from
+  # Out Of Memory errors.
   limits:
     cpu: 500m
     memory: 1Gi


### PR DESCRIPTION
Other changes:
- bumps the chart and app versions to latest
- removes the deprecated reference to agentId in helm values, which fixes issue #13 