### PR TITLE
Explicitly configure heap size in agent

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.0
+version: 0.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -49,3 +49,17 @@ Selector labels
 app.kubernetes.io/name: {{ include "superblocks-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Calculate heap size
+*/}}
+{{- define "superblocks-agent.heapSize" -}}
+{{- if hasSuffix "Mi" . -}}
+{{- $memoryLimit := trimSuffix "Mi" . -}}
+{{ min 512 (div $memoryLimit 2) }}
+{{- end }}
+{{- if hasSuffix "Gi" . -}}
+{{- $memoryLimit := mul (trimSuffix "Gi" .) 1024 -}}
+{{ min 512 (div $memoryLimit 2) }}
+{{- end }}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
               value: {{ required "superblocks.agentHostUrl is required!" .Values.superblocks.agentHostUrl | quote }}
             - name: SUPERBLOCKS_AGENT_ENVIRONMENT
               value: {{ default "*" .Values.superblocks.agentEnvironment | quote }}
+            {{- if ((.Values.resources | default dict ).limits | default dict).memory }}
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size={{ include "superblocks-agent.heapSize" .Values.resources.limits.memory }}"
+            {{- end }}
             {{- range $key, $val := .Values.extraEnv }}
             {{- if kindIs "map" $val }}
             - name: {{ $key }}

--- a/helm/templates/pdb.yaml
+++ b/helm/templates/pdb.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.podDisruptionBudget -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: policy/v1
+{{ else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "superblocks-agent.fullname" . }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -6,7 +6,6 @@
 # the https://app.superblockshq.com/opas Superblocks UI page
 # Ref: https://docs.superblockshq.com/superblocks/security-and-permissions/on-premise-agent-overview/deployment
 superblocks: {}
-#   agentId: ""
 #   agentKey: ""
 #   agentHostUrl: "http[s]://<agent-host[:port]>/agent"
 #   agentEnvironment: [staging|production|*]


### PR DESCRIPTION
Node versions v12+ begin setting heap sizes based on limits imposed by the cgroup. However, we're also spawning subprocesses as part of our JS and Python plugin executions so we should give ourselves some room for those processes to run. The heap itself doesn't seem to ever go over 100Mi, so I think it's safe to reserve a max of 512Mi for the heap of the main process. Any additional memory allocated should be for API executions.