### PR TITLE
configure highly available rolling upgrade with graceful agent shutdown

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -11,6 +11,13 @@ spec:
   selector:
     matchLabels:
       {{- include "superblocks-agent.selectorLabels" . | nindent 6 }}
+  {{- if not .Values.disableGracefulRollingUpdate }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -23,6 +30,7 @@ spec:
 {{ toYaml .Values.podLabels | indent 8 }}
         {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 86400 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -101,3 +101,13 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# If true, Kubernetes will not wait until the new pods are running
+# before terminating the old ones. Rather, It will create the new
+# pods at the same time it destroys the olds ones. Defults to false.
+# disableGracefulRollingUpdate: false
+
+# Upon termination, there may be inflight requests and scheduled jobs.
+# If you want to force kill the agent after a certain point, this value
+# is what you're looking for. Defaults to 1 day (86400 seconds). 
+# terminationGracePeriodSeconds: 86400


### PR DESCRIPTION
With this change, if there are `n` replicas of the agent running and a rolling upgrade is initiated, `n` replicas will always be running and available throughout the upgrade process.

Additionally, when Kubernetes issues a `SIGTERM` to the pod upon termination, the agent will be allowed to complete any inflight HTTP requests and scheduled jobs. The grace period allowed is dictated by a configurable Helm variable. 