### PR TITLE
[CI] Bump OPA version in chart to v0.33.0

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,15 +1,6 @@
 apiVersion: v2
-name: superblocks-agent
+appVersion: v0.33.0
 description: A Helm chart for the Superblocks On-Prem Agent
-
+name: superblocks-agent
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.31.0
+version: 0.21.0


### PR DESCRIPTION
Autogenerated PR to bump the App Version in the chart to v0.33.0.