### PR TITLE
Bump chart version

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v0.1.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 0.24.0
+version: 0.25.0


### PR DESCRIPTION
This PR bumps the chart version to 0.25.0, with which come the new agent platform architecture becomes available