### PR TITLE
Resume the version from where OPA left off

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: v0.1.0
+appVersion: v0.40.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 0.25.0
+version: 0.26.0


### PR DESCRIPTION
It is probably best to start from where we left off in terms of the existing agent versions since we show in-app upgrade notifications. This PR makes that assumption. DNM till the versions have been fixed