### PR TITLE
[CI] Bump OPA version in chart to v0.40.0

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v0.40.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 0.27.0
+version: 0.28.0


### PR DESCRIPTION
Autogenerated PR to bump the App Version in the chart to v0.40.0.