### PR TITLE
add service account creation and annotations

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v0.41.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 0.28.0
+version: 0.29.0

--- a/helm/templates/deployment-controller.yaml
+++ b/helm/templates/deployment-controller.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
-      serviceAccountName: {{ .Values.controller.serviceAccount.name }}
+      serviceAccountName: {{ default (include "superblocks-agent.controller.name" $) .Values.controller.serviceAccount.name }}
       containers:
       - name: {{ .Chart.Name }}-controller
         securityContext:

--- a/helm/templates/deployment-controller.yaml
+++ b/helm/templates/deployment-controller.yaml
@@ -20,15 +20,15 @@ spec:
       maxSurge: 100%
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with .Values.controller.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "superblocks-agent.selectorLabels" . | nindent 8 }}
         {{- include "superblocks-agent.controller.labels" . | nindent 8 }}
-        {{- if .Values.podLabels }}
-          {{ toYaml .Values.podLabels | indent 8 }}
+        {{- if .Values.controller.podLabels }}
+          {{ toYaml .Values.controller.podLabels | indent 8 }}
         {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds | default 86400 }}
@@ -38,6 +38,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ .Values.controller.serviceAccount.name }}
       containers:
       - name: {{ .Chart.Name }}-controller
         securityContext:

--- a/helm/templates/deployment-controller.yaml
+++ b/helm/templates/deployment-controller.yaml
@@ -20,15 +20,21 @@ spec:
       maxSurge: 100%
   template:
     metadata:
-      {{- with .Values.controller.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.controller.podAnnotations }}
+        {{- toYaml .Values.controller.podAnnotations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.commonPodAnnotations }}
+        {{- toYaml .Values.commonPodAnnotations | nindent 8 }}
       {{- end }}
       labels:
         {{- include "superblocks-agent.selectorLabels" . | nindent 8 }}
         {{- include "superblocks-agent.controller.labels" . | nindent 8 }}
         {{- if .Values.controller.podLabels }}
-          {{ toYaml .Values.controller.podLabels | indent 8 }}
+          {{- toYaml .Values.commonPodLabels | nindent 8 }}
+        {{- end }}
+        {{- if .Values.commonPodLabels }}
+          {{- toYaml .Values.commonPodLabels | nindent 8 }}
         {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds | default 86400 }}

--- a/helm/templates/deployment-worker.yaml
+++ b/helm/templates/deployment-worker.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml $.Values.worker.podSecurityContext | nindent 8 }}
-      serviceAccountName: {{ $.Values.worker.serviceAccount.name }}
+      serviceAccountName: {{ default (include "superblocks-agent.worker.name" $) $.Values.worker.serviceAccount.name }}
       containers:
       - name: {{ $.Chart.Name }}-worker
         securityContext:

--- a/helm/templates/deployment-worker.yaml
+++ b/helm/templates/deployment-worker.yaml
@@ -22,15 +22,15 @@ spec:
       maxSurge: 100%
   template:
     metadata:
-      {{- with $.Values.podAnnotations }}
+      {{- with $.Values.worker.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "superblocks-agent.selectorLabels" $ | nindent 8 }}
         {{- include "superblocks-agent.worker.labels" $k | nindent 8 }}
-        {{- if $.Values.podLabels }}
-          {{ toYaml $.Values.podLabels | indent 8 }}
+        {{- if $.Values.worker.podLabels }}
+          {{ toYaml $.Values.worker.podLabels | indent 8 }}
         {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds | default 86400 }}
@@ -40,6 +40,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml $.Values.worker.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ $.Values.worker.serviceAccount.name }}
       containers:
       - name: {{ $.Chart.Name }}-worker
         securityContext:

--- a/helm/templates/deployment-worker.yaml
+++ b/helm/templates/deployment-worker.yaml
@@ -22,15 +22,21 @@ spec:
       maxSurge: 100%
   template:
     metadata:
-      {{- with $.Values.worker.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+      {{- if $.Values.worker.podAnnotations }}
+        {{- toYaml $.Values.controller.podAnnotations | nindent 8 }}
+      {{- end }}
+      {{- if $.Values.commonPodAnnotations }}
+        {{- toYaml $.Values.commonPodAnnotations | nindent 8 }}
       {{- end }}
       labels:
         {{- include "superblocks-agent.selectorLabels" $ | nindent 8 }}
         {{- include "superblocks-agent.worker.labels" $k | nindent 8 }}
         {{- if $.Values.worker.podLabels }}
-          {{ toYaml $.Values.worker.podLabels | indent 8 }}
+          {{- toYaml $.Values.worker.podLabels | nindent 8 }}
+        {{- end }}
+        {{- if $.Values.commonPodLabels }}
+          {{- toYaml $.Values.commonPodLabels | nindent 8 }}
         {{- end }}
     spec:
       terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds | default 86400 }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $.Values.controller.serviceAccount.name }}
+  name: {{ default (include "superblocks-agent.controller.name" $) $.Values.controller.serviceAccount.name }}
   {{- with $.Values.controller.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -19,7 +19,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $.Values.worker.serviceAccount.name }}
+  name: {{ default (include "superblocks-agent.worker.name" $) $.Values.worker.serviceAccount.name }}
   {{- with $.Values.worker.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.controller.serviceAccount.create }}
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Values.controller.serviceAccount.name }}
+  {{- with $.Values.controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $.Values.controller.serviceAccount.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- if .Values.worker.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Values.worker.serviceAccount.name }}
+  {{- with $.Values.worker.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $.Values.worker.serviceAccount.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.controller.serviceAccount.create }}
 ---
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,6 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+
 {{- if .Values.worker.serviceAccount.create }}
 ---
 apiVersion: v1

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -97,7 +97,8 @@ controller:
 
   serviceAccount:
     create: true
-    name: superblocks-controller
+    # name: superblocks-agent-controller
+
     # If using Service Account Volume Token Projection to authenticate
     # OPA workloads, you must assign the IAM role to both the controller and worker service
     # accounts.
@@ -167,7 +168,8 @@ worker:
 
   serviceAccount:
     create: true
-    name: superblocks-worker
+    # name: superblocks-agent-worker
+
     # If using Service Account Volume Token Projection to authenticate
     # OPA workloads, you must assign the IAM role to both the controller and worker service
     # accounts.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -13,6 +13,9 @@ superblocks: {}
 
 imagePullSecrets: []
 
+commonPodAnnotations: {}
+commonPodLabels: {}
+
 # Change the prefix used in resource names.
 # Defaults to 'superblocks-agent'.
 nameOverride: ''

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -98,10 +98,17 @@ controller:
   serviceAccount:
     create: true
     name: superblocks-controller
+    # If using Service Account Volume Token Projection to authenticate
+    # OPA workloads, you must assign the IAM role to both the controller and worker service
+    # accounts.
     annotations: {}
+    # eks.amazonaws.com/role-arn: arn:aws:iam::111111111111:role/my-iam-role
+    # iam.gke.io/gcp-service-account=service-account@my-gcp-project.iam.gserviceaccount.com
     labels: {}
 
+  # If using something like kube2iam, pod annotations for roles would go here
   podAnnotations: {}
+  # iam.amazonaws.com/role: arn:aws:iam::111111111111:role/my-iam-role
   podLabels: {}
 
   autoscaling:
@@ -162,8 +169,8 @@ worker:
     create: true
     name: superblocks-worker
     # If using Service Account Volume Token Projection to authenticate
-    # OPA workloads, you must assign the IAM role to the worker service
-    # account. The worker is the component performing all the API steps.
+    # OPA workloads, you must assign the IAM role to both the controller and worker service
+    # accounts.
     annotations: {}
     # eks.amazonaws.com/role-arn: arn:aws:iam::111111111111:role/my-iam-role
     # iam.gke.io/gcp-service-account=service-account@my-gcp-project.iam.gserviceaccount.com

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -19,9 +19,6 @@ nameOverride: ''
 
 fullnameOverride: ''
 
-podAnnotations: {}
-podLabels: {}
-
 # Specify extra environment variables that will be applied
 # to both the Controllers and Workers.
 extraEnv: {}
@@ -95,6 +92,15 @@ controller:
   extraEnv: {}
   envFrom: []
 
+  serviceAccount:
+    create: true
+    name: superblocks-controller
+    annotations: {}
+    labels: {}
+
+  podAnnotations: {}
+  podLabels: {}
+
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -148,6 +154,22 @@ worker:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     # tag: ""
+
+  serviceAccount:
+    create: true
+    name: superblocks-worker
+    # If using Service Account Volume Token Projection to authenticate
+    # OPA workloads, you must assign the IAM role to the worker service
+    # account. The worker is the component performing all the API steps.
+    annotations: {}
+    # eks.amazonaws.com/role-arn: arn:aws:iam::111111111111:role/my-iam-role
+    # iam.gke.io/gcp-service-account=service-account@my-gcp-project.iam.gserviceaccount.com
+    labels: {}
+
+  # If using something like kube2iam, pod annotations for roles would go here
+  podAnnotations: {}
+  # iam.amazonaws.com/role: arn:aws:iam::111111111111:role/my-iam-role
+  podLabels: {}
 
   podSecurityContext: {}
   securityContext: {}


### PR DESCRIPTION
This allows users to configure annotations against their OPA workloads to leverage authentication methods such as kube2iam or service account token volume projection.