### PR TITLE
Stop using deprecated helm capabilities attribute

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v0.42.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 0.30.0
+version: 0.31.0

--- a/helm/templates/ingress-controller.yaml
+++ b/helm/templates/ingress-controller.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.controller.ingress.enabled -}}
 {{- $fullName := include "superblocks-agent.fullname" . -}}
 {{- $svcPort := .Values.controller.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -12,14 +14,14 @@ metadata:
   labels:
     {{- include "superblocks-agent.labels" . | nindent 4 }}
   annotations:
-    {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+    {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
     kubernetes.io/ingress.class: {{ .Values.controller.ingress.class }}
     {{- end }}
   {{- with .Values.controller.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.Version }}
   ingressClassName: {{ .Values.controller.ingress.class }}
   {{- end }}
   {{- if .Values.controller.ingress.tls }}

--- a/helm/templates/pdb-controller.yaml
+++ b/helm/templates/pdb-controller.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.controller.podDisruptionBudget -}}
 ---
-{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
 apiVersion: policy/v1
 {{ else }}
 apiVersion: policy/v1beta1

--- a/helm/templates/pdb-worker.yaml
+++ b/helm/templates/pdb-worker.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.worker.podDisruptionBudget -}}
 {{- range $k, $v := $.Values.worker.fleets }}
 ---
-{{- if semverCompare ">=1.21-0" $.Capabilities.KubeVersion.GitVersion }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" -}}
 apiVersion: policy/v1
 {{ else }}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
This makes the chart incompatible with Helm 2 but that's since gone EOL in 2020: https://github.com/helm/helm/releases/tag/v2.17.0