### PR TITLE
remove heapsize limit on agent

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v0.46.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 0.39.0
+version: 0.40.0

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -87,20 +87,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Calculate heap size
-*/}}
-{{- define "superblocks-agent.heapSize" -}}
-{{- if hasSuffix "Mi" . -}}
-{{- $memoryLimit := trimSuffix "Mi" . -}}
-{{ div $memoryLimit 2 }}
-{{- end }}
-{{- if hasSuffix "Gi" . -}}
-{{- $memoryLimit := mul (trimSuffix "Gi" .) 1024 -}}
-{{ div $memoryLimit 2 }}
-{{- end }}
-{{- end }}
-
-{{/*
 Generate certificates for controller <-> worker communication
 */}}
 {{- define "superblocks-agent.worker.tls" -}}

--- a/helm/templates/deployment-controller.yaml
+++ b/helm/templates/deployment-controller.yaml
@@ -92,10 +92,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
-        {{- if ((.Values.controller.resources | default dict ).limits | default dict).memory }}
-        - name: NODE_OPTIONS
-          value: "--max-old-space-size={{ include "superblocks-agent.heapSize" .Values.controller.resources.limits.memory }}"
-        {{- end }}
         {{- include "extra-env" (merge .Values.controller.extraEnv .Values.extraEnv) | indent 8 }}
         volumeMounts:
         - name: tls

--- a/helm/templates/deployment-worker.yaml
+++ b/helm/templates/deployment-worker.yaml
@@ -75,10 +75,6 @@ spec:
         {{- end }}
         - name: SUPERBLOCKS_AGENT_ENVIRONMENT
           value: {{ default "*" $.Values.superblocks.agentEnvironment | quote }}
-        {{- if (($v.resources | default dict ).limits | default dict).memory }}
-        - name: NODE_OPTIONS
-          value: "--max-old-space-size={{ include "superblocks-agent.heapSize" $v.resources.limits.memory }}"
-        {{- end }}
         {{- include "extra-env" (merge $v.extraEnv $.Values.worker.extraEnv $.Values.extraEnv) | indent 8 }}
         volumeMounts:
         - name: tls


### PR DESCRIPTION
We used to limit heapsize to half the allocated memory but this is not really needed anymore since workers are broken out of the service.