### PR TITLE
[CI] Bump OPA version in chart to v0.52.0

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: v0.50.0
+appVersion: v0.52.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 0.43.0
+version: 0.44.0


### PR DESCRIPTION
Autogenerated PR to bump the App Version in the chart to v0.52.0.