### PR TITLE
Bump helm-release-version to leveraged working versions upstream plugins

### DIFF
--- a/.github/workflows/deploy-chart.yml
+++ b/.github/workflows/deploy-chart.yml
@@ -21,7 +21,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_ROLE }}
       - name: Helm release
-        uses: superblocksteam/helm-release-action@v0.2
+        uses: superblocksteam/helm-release-action@v0.3
         with:
           repo: s3://superblocks-public-helm-repo/superblocks
           chart: ./helm


### PR DESCRIPTION
This makes use of an updated version of a forked github action, where we are now affixing versions of helm plugins. Currently, the latest version of `helm-s3` plugin is broken, and so in the action itself, we are affixing to an older version that was known to work.