### PR TITLE
Add support for specific path type in ingress object

### DIFF
--- a/helm/templates/ingress-controller.yaml
+++ b/helm/templates/ingress-controller.yaml
@@ -40,16 +40,20 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          {{- if semverCompare ">=1.14-0" $.Capabilities.KubeVersion.Version }}
-          - path: {{ . }}
+          {{- if and . (kindIs "map" .) }}
+          - path: {{ required "controller.ingress.hosts.paths[].path is required" .path | quote }}
+            pathType: {{ default "ImplementationSpecific" .pathType | quote }}
+          {{- else }}
+          - path: {{ quote . }}
             pathType: ImplementationSpecific
+          {{- end }}
+          {{- if semverCompare ">=1.14-0" $.Capabilities.KubeVersion.Version }}
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
           {{- else }}
-          - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -41,7 +41,6 @@ envFrom: []
 
 # Controller specific values.
 controller:
-
   service:
     type: ClusterIP
     port: 8020
@@ -55,6 +54,9 @@ controller:
     # - host: chart-example.local
     #   paths:
     #   - /
+    #   - path: /agent
+    #     pathType: Prefix
+    #   - path: /health
     tls: []
     # - secretName: chart-example-tls
     #   hosts:
@@ -128,7 +130,6 @@ controller:
       #           kube_container_name: nginx
       #     targetAverageValue: 123
 
-
   # Please adjust these values as needed depending on your workloads. Allotting less
   # than this could potentially cause your agents to crash from Out Of Memory errors.
   resources:
@@ -145,7 +146,6 @@ controller:
 
 # Worker specific values.
 worker:
-
   # The default replica count if:
   # 1) autoscaling is not enabled
   # 2) fleet specific replicaCount is not defined


### PR DESCRIPTION
This allows users to define paths in the following ways, where the path type defaults to `ImplementationSpecific` unless overriden by the specification of a `pathType`
```
paths:
  - path: /agent
     pathType: Prefix
  - /health
  - path: /dummy
```