### PR TITLE
Default fleet enabled to true

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v0.62.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 0.61.0
+version: 0.62.0

--- a/helm/templates/deployment-worker.yaml
+++ b/helm/templates/deployment-worker.yaml
@@ -1,5 +1,5 @@
 {{- range $k, $v := $.Values.worker.fleets }}
-{{- if $v.enabled }}
+{{- if (default true $v.enabled) }}
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Without this, any custom fleets are disabled by default unless `enabled: true` is set. 