### PR TITLE
Add file based readiness probe for worker (for both python and non-python workers)

### DIFF
--- a/helm/templates/deployment-worker.yaml
+++ b/helm/templates/deployment-worker.yaml
@@ -91,6 +91,11 @@ spec:
         - name: tls
           mountPath: /etc/config/tls
         {{- end }}
+        readinessProbe:
+          exec:
+            command:
+            - cat
+            - /tmp/worker_healthy
       volumes:
       {{- if $.Values.worker.tls.enabled }}
       - name: tls

--- a/helm/templates/deployment-worker.yaml
+++ b/helm/templates/deployment-worker.yaml
@@ -91,11 +91,9 @@ spec:
         - name: tls
           mountPath: /etc/config/tls
         {{- end }}
-        readinessProbe:
-          exec:
-            command:
-            - cat
-            - /tmp/worker_healthy
+        {{- if $v.readinessProbe }}
+        readinessProbe: {{ toYaml $v.readinessProbe | nindent 10 }}
+        {{- end }}
       volumes:
       {{- if $.Values.worker.tls.enabled }}
       - name: tls

--- a/helm/templates/deployment-worker.yaml
+++ b/helm/templates/deployment-worker.yaml
@@ -91,8 +91,9 @@ spec:
         - name: tls
           mountPath: /etc/config/tls
         {{- end }}
-        {{- if $v.readinessProbe }}
-        readinessProbe: {{ toYaml $v.readinessProbe | nindent 10 }}
+        {{- if $.Values.worker.readinessProbe }}
+        readinessProbe: {{- toYaml (merge (default (dict) $v.readinessProbe) $.Values.worker.readinessProbe) | nindent 10 }}
+         
         {{- end }}
       volumes:
       {{- if $.Values.worker.tls.enabled }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -247,6 +247,12 @@ worker:
       # This will be merged with the worker's autoscaling
       # settings. This is the higher priority.
       autoscaling: {}
+      # Enable the following once tested in staging
+      # readinessProbe:
+      #   exec:
+      #     command:
+      #     - cat
+      #     - /tmp/worker_healthy
 
     python:
       enabled: true
@@ -272,6 +278,12 @@ worker:
       #   runAsNonRoot: false
       #   runAsGroup: 0
       #   runAsUser: 0
+      # Enable the following once tested in staging
+      # readinessProbe:
+      #   exec:
+      #     command:
+      #     - cat
+      #     - /tmp/worker_healthy
       image:
         repository: ghcr.io/superblocksteam/agent-worker-python
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -229,7 +229,6 @@ worker:
   #     - cat
   #     - /tmp/worker_healthy
 
-
   # We recommend running two fleets for the most secure setup.
   # If you would like to run a single fleet, then you can use:
   #
@@ -281,7 +280,6 @@ worker:
       #   runAsNonRoot: false
       #   runAsGroup: 0
       #   runAsUser: 0
-      # TODO [ro] Enable the following once tested in staging
       image:
         repository: ghcr.io/superblocksteam/agent-worker-python
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -221,6 +221,15 @@ worker:
   tolerations: []
   affinity: {}
 
+  # TODO [ro] enable the default after testing in staging
+  readinessProbe: {}
+  # readinessProbe:
+  #   exec:
+  #     command:
+  #     - cat
+  #     - /tmp/worker_healthy
+
+
   # We recommend running two fleets for the most secure setup.
   # If you would like to run a single fleet, then you can use:
   #
@@ -247,12 +256,6 @@ worker:
       # This will be merged with the worker's autoscaling
       # settings. This is the higher priority.
       autoscaling: {}
-      # TODO [ro] Enable the following once tested in staging
-      # readinessProbe:
-      #   exec:
-      #     command:
-      #     - cat
-      #     - /tmp/worker_healthy
 
     python:
       enabled: true
@@ -279,11 +282,6 @@ worker:
       #   runAsGroup: 0
       #   runAsUser: 0
       # TODO [ro] Enable the following once tested in staging
-      # readinessProbe:
-      #   exec:
-      #     command:
-      #     - cat
-      #     - /tmp/worker_healthy
       image:
         repository: ghcr.io/superblocksteam/agent-worker-python
 
@@ -297,9 +295,3 @@ worker:
       extraEnv: {}
       envFrom: []
       autoscaling: {}
-      # TODO [ro] Enable the following once tested in staging
-      # readinessProbe:
-      #   exec:
-      #     command:
-      #     - cat
-      #     - /tmp/worker_healthy

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -247,7 +247,7 @@ worker:
       # This will be merged with the worker's autoscaling
       # settings. This is the higher priority.
       autoscaling: {}
-      # Enable the following once tested in staging
+      # TODO [ro] Enable the following once tested in staging
       # readinessProbe:
       #   exec:
       #     command:
@@ -278,7 +278,7 @@ worker:
       #   runAsNonRoot: false
       #   runAsGroup: 0
       #   runAsUser: 0
-      # Enable the following once tested in staging
+      # TODO [ro] Enable the following once tested in staging
       # readinessProbe:
       #   exec:
       #     command:
@@ -297,3 +297,9 @@ worker:
       extraEnv: {}
       envFrom: []
       autoscaling: {}
+      # TODO [ro] Enable the following once tested in staging
+      # readinessProbe:
+      #   exec:
+      #     command:
+      #     - cat
+      #     - /tmp/worker_healthy


### PR DESCRIPTION

## Context:
See more context from here https://app.clickup.com/t/8650101/EG-8449

1. Both non-python worker and python worker healthy files are being written.
2. https://github.com/superblocksteam/superblocks/pull/3006/files This PR will enable readiness prob in staging. (This enables it at worker level, so all the fleet type will have this en-abled)


## Tested cases:

Case1:
The following is when both fleet level readinessProbe and worker level readinessProbe are NOT defined (missing this property) The rendered template does not have this field 
<img width="758" alt="Screen Shot 2022-11-16 at 5 59 04 PM" src="https://user-images.githubusercontent.com/97197110/202313218-ebf947b7-f24f-45f3-88da-6902db64ffa1.png">

Case2:
The following is when worker level readinessProbe is defined to {}, and it's not defined in fleet level
The rendered template does not have this field 
<img width="667" alt="Screen Shot 2022-11-16 at 6 03 11 PM" src="https://user-images.githubusercontent.com/97197110/202313446-ac623316-40f6-4412-bb43-ffc62b9ad699.png">

Case3: 
The following is when worker level readinessProbe is defined to the correct value (cat /tmp/worker_healthy)
 and it's not defined in fleet level. *We are likely to use this when enabling this in our clould-agent fleet* 
<img width="567" alt="Screen Shot 2022-11-16 at 6 04 29 PM" src="https://user-images.githubusercontent.com/97197110/202313615-a6e62600-7c78-4d38-8b50-df4d96001127.png">
