### PR TITLE
Add quickstart.sh for OPA deployment on VMs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,3 +30,39 @@ Start Superblocks Agent
 sudo superblocks start
 
 ```
+
+##### Manual test for localhost
+- Configure an EC2 instance with AmazonLinux or Ubuntu
+- Install the script
+```
+sudo curl -SL https://raw.githubusercontent.com/superblocksteam/agent/main/scripts/quickstart.sh -o /usr/bin/superblocks
+sudo chmod +x /usr/bin/superblocks
+```
+- Configure agent key
+```
+sudo superblocks conf SUPERBLOCKS_AGENT_KEY [GET_YOUR_KEY_FROM_SUPERBLOCKS_APP]
+```
+- Start the agent (when staring for the first time, it will install docker and pull docker images)
+```
+sudo superblocks start
+```
+- Check if service is up
+```
+curl localhost:8020
+```
+
+##### Manual test for https
+- Configure an EC2 instance with AmazonLinux or Ubuntu
+- Install the script(same commands as above)
+- Configure agent key and other variables
+```
+sudo superblocks conf SUPERBLOCKS_AGENT_KEY [GET_YOUR_KEY_FROM_SUPERBLOCKS_APP]
+sudo superblocks conf SUPERBLOCKS_LETSENCRYPT_EMAIL [YOUR_EMAIL_ADDRESS]
+sudo superblocks conf SUPERBLOCKS_AGENT_HOST_URL https://YOUR.VALID.DOMAIN.COM
+sudo superblocks conf SUPERBLOCKS_PROXY_REPLICA_COUNT 1
+```
+- Make sure a CNAME record of the custom domain is created and pointed to the EC2 instance
+- Start the agent(as above)
+- Check localhost
+- Visit https://YOUR.VALID.DOMAIN.COM to validate is service is up for https
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,6 +3,8 @@
 ##### Supported OS
 - AmazonLinux
 - Ubuntu
+- CentOS
+- Debian
 
 ##### Install The Script
 ```
@@ -32,7 +34,7 @@ sudo superblocks start
 ```
 
 ##### Manual test for localhost
-- Configure an EC2 instance with AmazonLinux or Ubuntu
+- Configure a VM instance with AmazonLinux/Ubuntu/CentOS/Debian
 - Install the script
 ```
 sudo curl -SL https://raw.githubusercontent.com/superblocksteam/agent/main/scripts/quickstart.sh -o /usr/bin/superblocks
@@ -52,7 +54,7 @@ curl localhost:8020
 ```
 
 ##### Manual test for https
-- Configure an EC2 instance with AmazonLinux or Ubuntu
+- Configure a VM instance with AmazonLinux/Ubuntu/CentOS/Debian
 - Install the script(same commands as above)
 - Configure agent key and other variables
 ```
@@ -61,7 +63,7 @@ sudo superblocks conf SUPERBLOCKS_LETSENCRYPT_EMAIL [YOUR_EMAIL_ADDRESS]
 sudo superblocks conf SUPERBLOCKS_AGENT_HOST_URL https://YOUR.VALID.DOMAIN.COM
 sudo superblocks conf SUPERBLOCKS_PROXY_REPLICA_COUNT 1
 ```
-- Make sure a CNAME record of the custom domain is created and pointed to the EC2 instance
+- Make sure a CNAME or A record of the custom domain is created and pointed to the VM instance
 - Start the agent(as above)
 - Check localhost
 - Visit https://YOUR.VALID.DOMAIN.COM to validate is service is up for https

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,32 @@
+### Superblocks On-Premise-Agent Quickstart Deployment Script
+
+##### Supported OS
+- AmazonLinux
+- Ubuntu
+
+##### Install The Script
+```
+sudo curl -SL https://raw.githubusercontent.com/superblocksteam/agent/main/scripts/quickstart.sh -o /usr/bin/superblocks
+sudo chmod +x /usr/bin/superblocks
+```
+
+##### Usage
+Configuration
+```
+# Required
+sudo superblocks conf SUPERBLOCKS_AGENT_KEY [GET_YOUR_KEY_FROM_SUPERBLOCKS_APP]
+
+# In order to use custom domain and https
+sudo superblocks conf SUPERBLOCKS_LETSENCRYPT_EMAIL [YOUR_EMAIL_ADDRESS]
+sudo superblocks conf SUPERBLOCKS_AGENT_HOST_URL https://YOUR.VALID.DOMAIN.COM
+sudo superblocks conf SUPERBLOCKS_PROXY_REPLICA_COUNT 1
+```
+
+Start Superblocks Agent
+```
+# Usage: sudo superblocks COMMAND
+# Commands: [start/status/stop/conf/log]
+
+sudo superblocks start
+
+```

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+# Superblock On-Premise-Agent installation script for Linux
+# Supported OS:
+#   - AmazonLinux
+#   - Ubuntu
+
+set -e
+
+compose_yaml="https://raw.githubusercontent.com/superblocksteam/agent/main/docker/compose.yaml"
+env_file="/etc/superblocks.conf"
+log_file="/var/log/superblocks.log"
+
+get_distro() {
+    distro=""
+    if [ -r /etc/os-release ]; then
+        distro="$(. /etc/os-release && echo "$ID")"
+    fi
+    echo "$distro"
+}
+
+get_compose_cmd() {
+    if [ "$(get_distro)" = "amzn" ]; then
+        echo "docker-compose"
+    else
+        echo "docker compose"
+    fi
+}
+
+command_exists() {
+    command -v "$@" > /dev/null 2>&1
+}
+
+install_docker_on_linux() {
+    if !(command_exists docker); then
+        echo "Installing docker on $(get_distro)..."
+        /bin/sh -c "$(curl -fsSL https://get.docker.com/)"
+    fi
+}
+
+install_docker_on_amzn() {
+    if !(command_exists docker); then
+        echo "Installing docker on Amazon..."
+        #Install docker
+        yum update -y
+        amazon-linux-extras install docker
+
+        #Install docker-compose standalone
+        curl -SL https://github.com/docker/compose/releases/download/v2.12.2/docker-compose-linux-x86_64 -o /usr/bin/docker-compose
+        chmod +x /usr/bin/docker-compose
+    fi
+}
+
+install_docker() {
+    if [ "$(get_distro)" = "amzn" ]; then
+        install_docker_on_amzn
+    else
+        install_docker_on_linux
+    fi
+}
+
+stop() {
+    pid=$(ps aux | grep 'superblocks' | grep -v 'grep' | awk '{print $2}')
+    if [ -n "$pid" ]; then
+        echo "Stopping Superblocks On-Premise-Agent..."
+        kill $pid
+        echo ">>>On-Premise-Agent is stopped"
+    fi
+}
+
+status() {
+    docker ps --format "table {{.ID}}\t{{.Names}}\t{{.Status}}"
+}
+
+log() {
+    echo "Press Ctrl+C to stop logging..."
+    tail -f $log_file
+}
+
+conf() {
+    if [ "$1" = "clear" ]; then
+        rm $env_file
+        exit 1
+    fi
+
+    if [ -z "$1" ] | [ -z "$2" ]; then
+        echo "Key and value are required."
+        echo "Usage: ./quickstart.sh conf KEY VALUE"
+        exit 1
+    fi
+
+    if ! [ -e $env_file ]; then
+        touch $env_file
+    fi
+
+    if grep -q "$1" $env_file; then
+        sed -i "s/$1=.*/$1=$2/" $env_file
+    else
+        echo "$1=$2" >> $env_file
+    fi
+}
+
+show_instructions() {
+    echo "Superblocks On-Premise-Agent"
+    echo "Usage: sudo superblocks COMMAND"
+    echo "Commands: [start/status/stop/conf/log]"
+}
+
+start() {
+    # Install and run docker
+    # Docker's installation script doesn't support AmazonLinux
+    # and we need to install docker-compose standalone
+    install_docker
+
+    echo "Running docker..."
+    systemctl start docker
+
+    compose_cmd=$(get_compose_cmd)
+
+    # Launch OPA
+    echo "Starting Superblocks On-Premise-Agent..."
+    curl -s $1 | ${compose_cmd} -p superblocks --env-file $2 -f - up > $3 &
+}
+
+case "$1" in
+    ""|start)
+        start $compose_yaml $env_file $log_file
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status
+        ;;
+    conf)
+        conf $2 $3
+        ;;
+    log)
+        log
+        ;;
+    *)
+        show_instructions
+        ;;
+esac
+exit 1;


### PR DESCRIPTION
Implemented a script for installing docker and launching OPA on VMs

Tested on EC2/AmazonLinux and EC2/Ubuntu

A README.md file is also added to explain the usage.