### PR TITLE
Default letsencrypt email address to an empty string

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -18,7 +18,7 @@ x-environment: &environment
 services:
   proxy:
     # Configurable variables for traefik to set up https
-    # SUPERBLOCKS_LETSENCRYPT_EMAIL
+    # SUPERBLOCKS_LETSENCRYPT_EMAIL, default ''
     # SUPERBLOCKS_PROXY_REPLICA_COUNT, default 0
     # SUPERBLOCKS_LETSENCRYPT_DIR, default letsencrypt
     # SUPERBLOCKS_AGENT_DOMAIN, default .+
@@ -35,7 +35,7 @@ services:
       - '--providers.docker=true'
       - '--entrypoints.web.address=:80'
       - '--entrypoints.websecure.address=:443'
-      - '--certificatesresolvers.letsencrypt.acme.email=${SUPERBLOCKS_LETSENCRYPT_EMAIL}'
+      - '--certificatesresolvers.letsencrypt.acme.email=${SUPERBLOCKS_LETSENCRYPT_EMAIL:-}'
       - '--certificatesresolvers.letsencrypt.acme.storage=/${SUPERBLOCKS_LETSENCRYPT_DIR:-letsencrypt}/acme.json'
       - '--certificatesresolvers.letsencrypt.acme.httpchallenge=true'
       - '--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web'


### PR DESCRIPTION
This should be handled better when we eventually have a script and in-app optional selection