### PR TITLE
Only trigger chart release on helm changes

### DIFF
--- a/.github/workflows/deploy-chart.yml
+++ b/.github/workflows/deploy-chart.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'helm/**'
 
 jobs:
   release-chart:


### PR DESCRIPTION
This makes it so that the github workflow to release a new chart only triggers on changes to the helm dir