### PR TITLE
Add distro docker test files for quickstart.sh

### DIFF
--- a/scripts/distro-test/amzn/Dockerfile
+++ b/scripts/distro-test/amzn/Dockerfile
@@ -1,0 +1,5 @@
+FROM amazonlinux:latest
+
+RUN yum -y install curl && yum -y install sudo
+RUN sudo curl -SL https://raw.githubusercontent.com/superblocksteam/agent/main/scripts/quickstart.sh -o /usr/bin/superblocks && \
+sudo chmod +x /usr/bin/superblocks

--- a/scripts/distro-test/centos/Dockerfile
+++ b/scripts/distro-test/centos/Dockerfile
@@ -1,0 +1,8 @@
+FROM centos:latest
+
+RUN cd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN yum -y install curl && yum -y install sudo
+RUN sudo curl -SL https://raw.githubusercontent.com/superblocksteam/agent/main/scripts/quickstart.sh -o /usr/bin/superblocks && \
+sudo chmod +x /usr/bin/superblocks

--- a/scripts/distro-test/debian/Dockerfile
+++ b/scripts/distro-test/debian/Dockerfile
@@ -1,0 +1,5 @@
+FROM debian:latest
+
+RUN apt update -y && apt install -y curl && apt install -y sudo
+RUN sudo curl -SL https://raw.githubusercontent.com/superblocksteam/agent/main/scripts/quickstart.sh -o /usr/bin/superblocks && \
+sudo chmod +x /usr/bin/superblocks

--- a/scripts/distro-test/ubuntu/Dockerfile
+++ b/scripts/distro-test/ubuntu/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:latest
+
+RUN apt-get update -y && apt-get install -y curl && apt-get install -y sudo
+RUN sudo curl -SL https://raw.githubusercontent.com/superblocksteam/agent/main/scripts/quickstart.sh \
+    -o /usr/bin/superblocks && \
+    sudo chmod +x /usr/bin/superblocks


### PR DESCRIPTION
Added docker files to test installation of docker and superblocks quickstart script in 4 linux distributions.
- AmazonLinux
- CentOS
- Debian
- Ubuntu