### PR TITLE
Create workflow to test quickstart.sh

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,45 @@
+name: Test quickstart.sh On Different Distros
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  test-amazon-linux:
+
+    runs-on: centos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the AmazonLinux Docker image
+      run: docker build scripts/distro-test/amzn/Dockerfile
+  
+  test-centos:
+
+    runs-on: centos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the CentOS Docker image
+      run: docker build scripts/distro-test/centos/Dockerfile
+      
+  test-debian:
+
+    runs-on: debian-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Debian Docker image
+      run: docker build scripts/distro-test/debian/Dockerfile
+      
+  test-ubuntu:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Ubuntu Docker image
+      run: docker build scripts/distro-test/ubuntu/Dockerfile


### PR DESCRIPTION
Create workflow to test quickstart.sh on linux distros:
- AmazonLinux
- CentOS
- Debian
- Ubuntu