### PR TITLE
Switch from node worker to python worker for python fleet

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v0.63.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 0.66.0
+version: 0.67.0

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -272,18 +272,9 @@ worker:
       #   runAsNonRoot: false
       #   runAsGroup: 0
       #   runAsUser: 0
-      # NOTE(taha) There are connectivity issues between the python-specific worker
-      # and the controllers currently. I'm going to temporarily cut out the
-      # use of the python-based worker in favor of the node-based worker that
-      # supports the python plugin, albeit less performantly.
-      # image:
-      #     repository: ghcr.io/superblocksteam/worker-python
-      #     tag: v0.48.0
-      # This image is being affixed to an older version of the worker image that
-      # contains the python runtime
       image:
-        repository: ghcr.io/superblocksteam/agent-worker
-        tag: v0.62.0
+        repository: ghcr.io/superblocksteam/worker-python
+        tag: v0.53.0
 
     not-language:
       # You can disable the default fleet options


### PR DESCRIPTION
This switches us back to the python-based worker that gives us over an order of magnitude in perf improvements for python steps.

The latest version contains fixes for 
- unhandled exceptions
- socketio connectivity
- binary data handling