### PR TITLE
Specify flags to keep the distributed mode active

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -57,6 +57,7 @@ services:
       <<: *environment
       SUPERBLOCKS_WORKER_METRICS_PORT: ${SUPERBLOCKS_WORKER_METRICS_PORT:-9090}
       SUPERBLOCKS_WORKER_PLUGINS: "!python"
+      SUPERBLOCKS_CONTROLLER_DISCOVERY_ENABLED: "true"
     ports:
       - '${SUPERBLOCKS_WORKER_METRICS_PORT:-9090}'
     restart: unless-stopped
@@ -68,6 +69,7 @@ services:
       <<: *environment
       SUPERBLOCKS_WORKER_METRICS_PORT: ${SUPERBLOCKS_WORKER_METRICS_PORT:-9091}
       SUPERBLOCKS_WORKER_PLUGINS: "python"
+      SUPERBLOCKS_CONTROLLER_DISCOVERY_ENABLED: "true"
     ports:
       - '${SUPERBLOCKS_WORKER_METRICS_PORT:-9091}'
     restart: unless-stopped
@@ -77,6 +79,7 @@ services:
     pull_policy: ${SUPERBLOCKS_DOCKER_IMAGE_PULL_POLICY:-always}
     environment:
       <<: *environment
+      __SUPERBLOCKS_WORKER_LOCAL_ENABLED: "false"
     ports:
       - '${SUPERBLOCKS_AGENT_PORT:-8020}:${SUPERBLOCKS_AGENT_PORT:-8020}'
       - '${SUPERBLOCKS_WORKER_PORT:-5001}'

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: v0.67.0
+appVersion: v0.68.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 0.70.0
+version: 0.71.0

--- a/helm/templates/deployment-controller.yaml
+++ b/helm/templates/deployment-controller.yaml
@@ -97,6 +97,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: __SUPERBLOCKS_WORKER_LOCAL_ENABLED
+          value: "true"
         {{- include "extra-env" (merge .Values.controller.extraEnv .Values.extraEnv) | indent 8 }}
         volumeMounts:
         {{- if $.Values.worker.tls.enabled }}

--- a/helm/templates/deployment-worker.yaml
+++ b/helm/templates/deployment-worker.yaml
@@ -85,6 +85,8 @@ spec:
         {{- end }}
         - name: SUPERBLOCKS_AGENT_ENVIRONMENT
           value: {{ default "*" $.Values.superblocks.agentEnvironment | quote }}
+        - name: SUPERBLOCKS_CONTROLLER_DISCOVERY_ENABLED
+          value: "true"
         {{- include "extra-env" (merge $v.extraEnv $.Values.worker.extraEnv $.Values.extraEnv) | indent 8 }}
         volumeMounts:
         {{- if $.Values.worker.tls.enabled }}


### PR DESCRIPTION
This PR ensures that existing users of the docker compose and helm charts do not pick up the simplified execution mode right now