### PR TITLE
Added annotations support to service-controller template.

### DIFF
--- a/helm/templates/service-controller.yaml
+++ b/helm/templates/service-controller.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "superblocks-agent.fullname" . }}
   labels:
     {{- include "superblocks-agent.labels" . | nindent 4 }}
+  {{- with .Values.controller.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.controller.service.type }}
   ports:


### PR DESCRIPTION
This PR adds support to add annotations via `values.yaml` for the service-controller.

Example:
```yaml
controller:
  service:
    type: NodePort
    port: 8020
    annotations:
      cloud.google.com/backend-config: '{"ports": { "http":"superblocks-backend-config" }}'
```