### PR TITLE
Add in the ability to inject in additional resources 

### DIFF
--- a/helm/templates/extra-manifests.yaml
+++ b/helm/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -38,6 +38,17 @@ envFrom: []
 #   - configMapRef:
 #       name: my-agent-env-configmap
 
+# Specify additional manifests that will be applied as part of the release
+extraManifests: []
+# extraManifests:
+#  - apiVersion: cloud.google.com/v1beta1
+#    kind: BackendConfig
+#    metadata:
+#      name: "{{ .Release.Name }}-test"
+#    spec:
+#      securityPolicy:
+#        name: "gcp-cloud-armor-policy-test"
+
 # This node is being maintained for legacy reasons.
 controller:
   service:


### PR DESCRIPTION
# Description
This PR is being raised to allow additional resources to be injected in as part of the helm release. 

Kubernetes configurations can differ quite significantly from cluster to cluster and this PR provides the flexibility to add any additional resources users may require in their configuration. 

