### PR TITLE
Install curl only when it doesn't exist in amzn distro

### DIFF
--- a/scripts/distro-test/amzn/Dockerfile
+++ b/scripts/distro-test/amzn/Dockerfile
@@ -1,5 +1,6 @@
 FROM amazonlinux:latest
 
-RUN yum -y install curl sudo
+RUN yum -y install sudo
+RUN if ! [ -x "$(command -v curl)" ]; then yum -y install curl fi
 RUN sudo curl -SL https://raw.githubusercontent.com/superblocksteam/agent/main/scripts/quickstart.sh -o /usr/bin/superblocks && \
   sudo chmod +x /usr/bin/superblocks


### PR DESCRIPTION
Within distro AMZN-2023, curl-minimal is installed by default.
We only install `curl` when the command doesn't exist.