### PR TITLE
[CI] Bump OPA version in chart to v1.0.0

### DIFF
--- a/helm/v1/Chart.yaml
+++ b/helm/v1/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: v0.107.0
+appVersion: v1.0.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 1.22.0
+version: 1.23.0


### PR DESCRIPTION
Autogenerated PR to bump the App Version in the chart to v1.0.0.