### PR TITLE
Fix amazonlinux image build

### DIFF
--- a/scripts/distro-test/amzn/Dockerfile
+++ b/scripts/distro-test/amzn/Dockerfile
@@ -1,5 +1,5 @@
 FROM amazonlinux:latest
 
-RUN yum -y install curl sudo
+RUN yum -y install sudo
 RUN sudo curl -SL https://raw.githubusercontent.com/superblocksteam/agent/main/scripts/quickstart.sh -o /usr/bin/superblocks && \
   sudo chmod +x /usr/bin/superblocks


### PR DESCRIPTION
Curl comes pre-installed in the latest amazonlinux base images