### PR TITLE
[CI] Bump OPA version in chart to v1.2.0

### DIFF
--- a/helm/v2/Chart.yaml
+++ b/helm/v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: v1.0.15
+appVersion: v1.2.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 2.8.0
+version: 2.9.0


### PR DESCRIPTION
Autogenerated PR to bump the App Version in the chart to v1.2.0.