### PR TITLE
Support Service Annotations

### DIFF
--- a/helm/v2/templates/service.yaml
+++ b/helm/v2/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "superblocks-agent.fullname" . }}
   labels:
     {{- include "superblocks-agent.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/v2/values.yaml
+++ b/helm/v2/values.yaml
@@ -96,7 +96,7 @@ service:
     metrics: 9090
   
   # If you have cloud specific service annotations, you can add them here.
-  annotations:
+  annotations: {}
     # cloud.google.com/neg: '{"ingress": true}'
     # cloud.google.com/backend-config: '{"ports": {"http": "superblocks-agent-backend"}}'
 

--- a/helm/v2/values.yaml
+++ b/helm/v2/values.yaml
@@ -94,6 +94,11 @@ service:
     grpc: 8081
     http: 8080
     metrics: 9090
+  
+  # If you have cloud specific service annotations, you can add them here.
+  annotations:
+    # cloud.google.com/neg: '{"ingress": true}'
+    # cloud.google.com/backend-config: '{"ports": {"http": "superblocks-agent-backend"}}'
 
 logLevel: info
 


### PR DESCRIPTION
Service Annotations for the OPA allow GKE users to add NEG and Backend Config annotations for configuring GCE ingress.