### PR TITLE
Pass grpc limits as environment variables and parse as ints

### DIFF
--- a/helm/v2/Chart.yaml
+++ b/helm/v2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v1.3.1
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 2.13.0
+version: 2.14.0

--- a/helm/v2/templates/deployment.yaml
+++ b/helm/v2/templates/deployment.yaml
@@ -63,10 +63,10 @@ spec:
         - "--grpc.port={{ .Values.service.ports.grpc }}"
         - "--metrics.port={{ .Values.service.ports.metrics }}"
         {{- if (.Values.grpc).maxMsgSize }}
-        - "--grpc.msg.res.max={{.Values.grpc.maxMsgSize}}"
+        - "--grpc.msg.res.max={{.Values.grpc.maxMsgSize | int64}}"
         {{- end }}
         {{- if (.Values.grpc).maxRecvMsgSize }}
-        - "--grpc.msg.req.max={{.Values.grpc.maxRecvMsgSize}}"
+        - "--grpc.msg.req.max={{.Values.grpc.maxRecvMsgSize | int64}}"
         {{- end }}
         - "--superblocks.url={{.Values.superblocks.serverUrl}}"
         {{- if .Values.superblocks.timeout }}}

--- a/helm/v2/templates/deployment.yaml
+++ b/helm/v2/templates/deployment.yaml
@@ -62,12 +62,6 @@ spec:
         - "--http.port={{ .Values.service.ports.http }}"
         - "--grpc.port={{ .Values.service.ports.grpc }}"
         - "--metrics.port={{ .Values.service.ports.metrics }}"
-        {{- if (.Values.grpc).maxMsgSize }}
-        - "--grpc.msg.res.max={{.Values.grpc.maxMsgSize | int64}}"
-        {{- end }}
-        {{- if (.Values.grpc).maxRecvMsgSize }}
-        - "--grpc.msg.req.max={{.Values.grpc.maxRecvMsgSize | int64}}"
-        {{- end }}
         - "--superblocks.url={{.Values.superblocks.serverUrl}}"
         {{- if .Values.superblocks.timeout }}}
         - "--superblocks.timeout={{ .Values.superblocks.timeout }}"
@@ -108,7 +102,15 @@ spec:
         {{- end }}
         {{- if .Values.extraEnv }}
         env:
-        {{- include "extra-env" .Values.extraEnv | indent 8 }}
+        {{- if (.Values.grpc).maxMsgSize }}
+          - name: SUPERBLOCKS_ORCHESTRATOR_GRPC_MSG_RES_MAX
+            value: {{.Values.grpc.maxMsgSize | int64 | quote}}
+        {{- end }}
+        {{- if (.Values.grpc).maxRecvMsgSize }}
+          - name: SUPERBLOCKS_ORCHESTRATOR_GRPC_MSG_REQ_MAX
+            value: {{.Values.grpc.maxRecvMsgSize | int64 | quote}}
+        {{- end }}
+        {{- include "extra-env" .Values.extraEnv | indent 10 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/v2/values.yaml
+++ b/helm/v2/values.yaml
@@ -70,8 +70,8 @@ extraContainers: []
   #   - /cloud_sql_proxy
   #   - -instances=10.0.0.1:5432
   #   - -credential_file=/secrets/cloudsql/credentials.json
-  #   image:
-  #   name:
+  #   image: 
+  #   name: 
   #   volumeMounts:
   #   - mountPath: /secrets/cloudsql
   #     name: cloudsql-sa-volume

--- a/helm/v2/values.yaml
+++ b/helm/v2/values.yaml
@@ -34,9 +34,9 @@ commonPodLabels: {}
 
 # Change the prefix used in resource names.
 # Defaults to 'superblocks-agent'.
-nameOverride: ""
+nameOverride: ''
 
-fullnameOverride: ""
+fullnameOverride: ''
 
 # Specify extra environment variables that will be applied
 extraEnv: {}
@@ -65,8 +65,7 @@ extraManifests: []
 #        name: "gcp-cloud-armor-policy-test"
 
 # Specify additional containers that should be added
-extraContainers:
-  []
+extraContainers: []
   # - command:
   #   - /cloud_sql_proxy
   #   - -instances=10.0.0.1:5432
@@ -78,8 +77,7 @@ extraContainers:
   #     name: cloudsql-sa-volume
 
 # Specify init containers that should be added
-initContainers:
-  []
+initContainers: []
   # - name:
   #   image:
   #   volumeMounts:
@@ -106,8 +104,7 @@ grpc:
 ingress:
   enabled: false
   class: "" # nginx
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/tls-acme: "true"
   hosts: []
   # - host: chart-example.local
@@ -123,8 +120,7 @@ ingress:
 # is what you're looking for. Defaults to 30 minutes (1800 seconds).
 terminationGracePeriodSeconds: 1800
 
-podDisruptionBudget:
-  {}
+podDisruptionBudget: {}
   # minAvailable: 1
 
 image:
@@ -133,12 +129,10 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   # tag: ""
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -170,8 +164,7 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 40
   targetMemoryUtilizationPercentage: 80
-  customMetrics:
-    []
+  customMetrics: []
     # - type: External
     #   external:
     #     metricName: nginx.net.request_per_s

--- a/helm/v2/values.yaml
+++ b/helm/v2/values.yaml
@@ -34,9 +34,9 @@ commonPodLabels: {}
 
 # Change the prefix used in resource names.
 # Defaults to 'superblocks-agent'.
-nameOverride: ''
+nameOverride: ""
 
-fullnameOverride: ''
+fullnameOverride: ""
 
 # Specify extra environment variables that will be applied
 extraEnv: {}
@@ -65,19 +65,21 @@ extraManifests: []
 #        name: "gcp-cloud-armor-policy-test"
 
 # Specify additional containers that should be added
-extraContainers: []
+extraContainers:
+  []
   # - command:
   #   - /cloud_sql_proxy
   #   - -instances=10.0.0.1:5432
   #   - -credential_file=/secrets/cloudsql/credentials.json
-  #   image: 
-  #   name: 
+  #   image:
+  #   name:
   #   volumeMounts:
   #   - mountPath: /secrets/cloudsql
   #     name: cloudsql-sa-volume
 
 # Specify init containers that should be added
-initContainers: []
+initContainers:
+  []
   # - name:
   #   image:
   #   volumeMounts:
@@ -99,11 +101,13 @@ logLevel: info
 
 grpc:
   maxMsgSize:
+  maxRecvMsgSize:
 
 ingress:
   enabled: false
   class: "" # nginx
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/tls-acme: "true"
   hosts: []
   # - host: chart-example.local
@@ -119,7 +123,8 @@ ingress:
 # is what you're looking for. Defaults to 30 minutes (1800 seconds).
 terminationGracePeriodSeconds: 1800
 
-podDisruptionBudget: {}
+podDisruptionBudget:
+  {}
   # minAvailable: 1
 
 image:
@@ -128,10 +133,12 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   # tag: ""
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -163,7 +170,8 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 40
   targetMemoryUtilizationPercentage: 80
-  customMetrics: []
+  customMetrics:
+    []
     # - type: External
     #   external:
     #     metricName: nginx.net.request_per_s

--- a/helm/v2/values.yaml
+++ b/helm/v2/values.yaml
@@ -97,9 +97,11 @@ service:
 
 logLevel: info
 
+# The following is used to configure how much data the agent can receive or send.
+# If you are producing large outputs in your workloads, you may want to adjust this value
 grpc:
-  maxMsgSize:
-  maxRecvMsgSize:
+  maxMsgSize: 100000000 # 100MB
+  maxRecvMsgSize: 100000000 # 100MB
 
 ingress:
   enabled: false


### PR DESCRIPTION
These limits apply to the JS /  Python workers as well, so need to be env variables.

Also, Helm converts the values to scientific notation resulting  in: 
`invalid argument "1e+08" for "--grpc.msg.req.max" flag: strconv.ParseInt: parsing "1e+08": invalid syntax`
Add int64 type to fix that.