### PR TITLE
[CI] Bump OPA version in chart to v1.4.2

### DIFF
--- a/helm/v2/Chart.yaml
+++ b/helm/v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: v1.3.2
+appVersion: v1.4.2
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 2.15.0
+version: 2.16.0


### PR DESCRIPTION
Autogenerated PR to bump the App Version in the chart to v1.4.2.