### PR TITLE
make various values of liveness probe configurable

### DIFF
--- a/helm/v2/Chart.yaml
+++ b/helm/v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: v1.5.0
+appVersion: v1.6.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 2.18.0
+version: 2.19.0

--- a/helm/v2/templates/deployment.yaml
+++ b/helm/v2/templates/deployment.yaml
@@ -68,19 +68,9 @@ spec:
           containerPort: {{ .Values.service.ports.metrics }}
           protocol: TCP
         livenessProbe:
-          periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
-          initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
-          failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
-          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
-          httpGet:
-            path: /health
-            port: http
+          {{- toYaml .Values.probes.liveness | nindent 10 }}
         readinessProbe:
-          periodSeconds: 15
-          initialDelaySeconds: 0
-          httpGet:
-            path: /health 
-            port: http
+          {{- toYaml .Values.probes.readiness | nindent 10 }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         envFrom:

--- a/helm/v2/templates/deployment.yaml
+++ b/helm/v2/templates/deployment.yaml
@@ -68,12 +68,18 @@ spec:
           containerPort: {{ .Values.service.ports.metrics }}
           protocol: TCP
         livenessProbe:
+          periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+          failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
           httpGet:
             path: /health
             port: http
         readinessProbe:
+          periodSeconds: 15
+          initialDelaySeconds: 0
           httpGet:
-            path: /health
+            path: /health 
             port: http
         resources:
           {{- toYaml .Values.resources | nindent 10 }}

--- a/helm/v2/values.yaml
+++ b/helm/v2/values.yaml
@@ -195,6 +195,15 @@ probes:
     periodSeconds: 15
     timeoutSeconds: 2
     failureThreshold: 5
+    httpGet:
+      path: /health
+      port: http
+  readiness:
+    periodSeconds: 15
+    initialDelaySeconds: 0
+    httpGet:
+      path: /health 
+      port: http
 
 nodeSelector: {}
 tolerations: []

--- a/helm/v2/values.yaml
+++ b/helm/v2/values.yaml
@@ -189,6 +189,13 @@ resources:
     cpu: 1
     memory: 4Gi
 
+probes:
+  liveness:
+    initialDelaySeconds: 15
+    periodSeconds: 15
+    timeoutSeconds: 2
+    failureThreshold: 5
+
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
Fixes #250 

The agent takes a while for `/health` to return successful. This is because we wait for all subprocess to be completely healthy. We might want to consider using a different success criteria for liveness that differs from the one used for readiness but for now, we'll just introduce a configurable delay. This should reduce/remove the flakiness on pod startup.