### PR TITLE
[CI] Bump OPA version in chart to v1.7.0

### DIFF
--- a/helm/v2/Chart.yaml
+++ b/helm/v2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v1.7.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 2.21.0
+version: 2.22.0


### PR DESCRIPTION
Autogenerated PR to bump the App Version in the chart to v1.7.0.