### PR TITLE
Fixes incorrect indent level for extraEnvs include

### DIFF
--- a/helm/v2/Chart.yaml
+++ b/helm/v2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v1.6.1
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 2.20.0
+version: 2.20.1

--- a/helm/v2/templates/deployment.yaml
+++ b/helm/v2/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
           value: {{.Values.grpc.maxRecvMsgSize | int64 | quote}}
         {{- end }}
         {{- if .Values.extraEnv }}
-        {{- include "extra-env" .Values.extraEnv | indent 10 }}
+        {{- include "extra-env" .Values.extraEnv | indent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Description
This pull request fixes an issue encountered when using `extraEnvs` with the `helm/v2` chart, specifically version 2.20.0. The `indent` level of `10` is `2` levels too deep and causes the yaml parser to fail (see screenshots). Changing this to a level of `8` resolve the issue.

## How Has This Been Tested?

*Pre-requisites*:
* `helm` cli is installed

This can be tested easily by following these steps:
1. Clone the `superblocksteam/agent` repo
2. Change directory into `helm/v2`
3. Edit the `values.yaml` to uncomment the example `extraEnv` values
```yaml
extraEnv: {}
  TEST_KEY: foobar
  DD_AGENT_HOST:
    valueFrom:
      fieldRef:
        fieldPath: status.hostIP
```
4. Run the following command
```sh
$ helm --dry-run --debug template superblocks-agent . \
  -f values.yaml \
  --set superblocks.agentDataDomain='app.superblocks.com' \
  --set superblocks.agentKey='<agentKey>' \
  --set superblocks.agentTags='profile:*'
```

Expected Output:

```yaml
# Source: superblocks-agent/templates/deployment.yaml
...
        env:
        - name: SUPERBLOCKS_ORCHESTRATOR_DATA_DOMAIN
          value: app.superblocks.com
 ...
        - name: SUPERBLOCKS_ORCHESTRATOR_GRPC_MSG_REQ_MAX
          value: "100000000"
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        - name: TEST_KEY
          value: "foobar"
```

Actual Output:

```yaml
# Source: superblocks-agent/templates/deployment.yaml
...
        env:
        - name: SUPERBLOCKS_ORCHESTRATOR_DATA_DOMAIN
          value: app.superblocks.com
 ...
        - name: SUPERBLOCKS_ORCHESTRATOR_GRPC_MSG_REQ_MAX
          value: "100000000"
          - name: DD_AGENT_HOST
            valueFrom:
              fieldRef:
                fieldPath: status.hostIP
          - name: TEST_KEY
            value: "foobar"
...
Error: YAML parse error on superblocks-agent/templates/deployment.yaml: error converting YAML to JSON: yaml: line 104: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 104: did not find expected key
YAML parse error on superblocks-agent/templates/deployment.yaml
<...stacktrace...>
```

## Screenshots (if appropriate):
<img width="1087" alt="image" src="https://github.com/superblocksteam/agent/assets/1121052/06bba294-5ad8-4ff2-b450-98e04dc32256">
