### PR TITLE
Revert "Bump Chart to 1.16.0 (#290)"

### DIFF
--- a/helm/agent/Chart.yaml
+++ b/helm/agent/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
-appVersion: v1.16.0
+appVersion: v1.14.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 2.33.0
+version: 2.32.0


### PR DESCRIPTION
This reverts commit 71607cdd01943cbced423bd6d970959cd1b681bb.