### PR TITLE
fix linting error in templates/ingress.yaml

### DIFF
--- a/helm/agent/templates/ingress.yaml
+++ b/helm/agent/templates/ingress.yaml
@@ -61,7 +61,7 @@ spec:
           {{- end }}
     {{- end }}
 ---
-{{- $grpcPort := .Values.service.ports.grpc -}}
+{{ $grpcPort := .Values.service.ports.grpc -}}
 {{- $services := list "/grpc.reflection.v1.ServerReflection" "/grpc.reflection.v1alpha.ServerReflection" "/api.v1.ExecutorService" }}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
# Issue
Helmfile reports linting errors when running `helmfile lint` against the chart version `2.33.0`

The import part of the helmfile.yaml is

```
 {{ define "app" }}
  - name: superblocks
    namespace: superblocks
    chart: superblocks/superblocks-agent
    # See https://github.com/superblocksteam/agent/blob/main/helm/agent/Chart.yaml
    version: 2.33.0
```

Output of ` helmfile lint  -l cluster=mycluster`, which then executes this `helm` command
```
    0: helm (4 bytes)
    1: lint (4 bytes)0
    2: /var/folders/cd/8lqzgfdd1d9frbh5fyw5__y40000gn/T/helmfile3338445168/superblocks/my-cluster/superblocks/superblocks/superblocks-agent/2.33.0/superblocks-agent (158 bytes)
    3: --namespace (11 bytes)
    4: superblocks (11 bytes)
    5: --values (8 bytes)
    6: /var/folders/cd/8lqzgfdd1d9frbh5fyw5__y40000gn/T/helmfile2599907847/superblocks-superblocks-values-5444786cd5 (109 bytes)
    7: --values (8 bytes)
    8: /var/folders/cd/8lqzgfdd1d9frbh5fyw5__y40000gn/T/helmfile1868541682/superblocks-superblocks-values-7554fd7d9b (109 bytes)
    9: --values (8 bytes)
    10: /var/folders/cd/8lqzgfdd1d9frbh5fyw5__y40000gn/T/helmfile1581026463/superblocks-superblocks-values-544f664978 (109 bytes)
    11: --values (8 bytes)
    12: /var/folders/cd/8lqzgfdd1d9frbh5fyw5__y40000gn/T/helmfile301610849/superblocks-superblocks-values-7669b4d894 (108 bytes)
    13: --values (8 bytes)
    14: /var/folders/cd/8lqzgfdd1d9frbh5fyw5__y40000gn/T/helmfile2308788539/superblocks-superblocks-values-84599f76cc (109 bytes)
    15: --values (8 bytes)
    16: /var/folders/cd/8lqzgfdd1d9frbh5fyw5__y40000gn/T/helmfile1770800373/superblocks-superblocks-values-8654599db (108 bytes)
    17: --values (8 bytes)
    18: /var/folders/cd/8lqzgfdd1d9frbh5fyw5__y40000gn/T/helmfile2656297725/superblocks-superblocks-values-5c7b78d7fc (109 bytes)
    19: --values (8 bytes)
    20: /var/folders/cd/8lqzgfdd1d9frbh5fyw5__y40000gn/T/helmfile3471344559/superblocks-superblocks-values-6bb8b4cd47 (109 bytes)
```

Error:
```
ERROR:
    exit status 1

  EXIT STATUS
    1

  STDERR:
    Error: 1 chart(s) linted, 1 chart(s) failed

  COMBINED OUTPUT:
    Error: 1 chart(s) linted, 1 chart(s) failed
    ==> Linting /var/folders/cd/8lqzgfdd1d9frbh5fyw5__y40000gn/T/helmfile3338445168/superblocks/ap1-staging/superblocks/superblocks/superblocks-agent/2.33.0/superblocks-agent
    [INFO] Chart.yaml: icon is recommended
    [ERROR] templates/ingress.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: networking.k8s.io/v1
```

While this fails, the `diff` actually seems to work
```
❯ helmfile diff  -l cluster=my-cluster context 1
awssecrets: successfully retrieved key=global/superblocks/agent
awssecrets: successfully retrieved key=global/superblocks/agent
awssecrets: successfully retrieved key=global/superblocks/agent
Adding repo superblocks https://charts.superblocks.com/superblocks
"superblocks" has been added to your repositories

Comparing release=superblocks, chart=superblocks/superblocks-agent, namespace=superblocks
superblocks, superblocks, Ingress (networking.k8s.io) has changed:
...
    labels:
-     helm.sh/chart: superblocks-agent-2.26.0
-     app.kubernetes.io/version: "v1.9.0"
+     helm.sh/chart: superblocks-agent-2.33.0
+     app.kubernetes.io/version: "v1.16.0"
      app.kubernetes.io/managed-by: Helm
...
superblocks, superblocks, Secret (v1) has changed:
...
      app.kubernetes.io/managed-by: Helm
-     app.kubernetes.io/version: v1.9.0
-     helm.sh/chart: superblocks-agent-2.26.0
+     app.kubernetes.io/version: v1.16.0
+     helm.sh/chart: superblocks-agent-2.33.0
    name: superblocks
...
superblocks, superblocks, Service (v1) has changed:
...
    labels:
-     helm.sh/chart: superblocks-agent-2.26.0
-     app.kubernetes.io/version: "v1.9.0"
+     helm.sh/chart: superblocks-agent-2.33.0
+     app.kubernetes.io/version: "v1.16.0"
      app.kubernetes.io/managed-by: Helm
...
superblocks, superblocks-agent, Deployment (apps) has changed:
...
    labels:
-     helm.sh/chart: superblocks-agent-2.26.0
-     app.kubernetes.io/version: "v1.9.0"
+     helm.sh/chart: superblocks-agent-2.33.0
+     app.kubernetes.io/version: "v1.16.0"
      app.kubernetes.io/managed-by: Helm
...
          app.kubernetes.io/instance: superblocks
-         helm.sh/chart: superblocks-agent-2.26.0
-         app.kubernetes.io/version: "v1.9.0"
+         helm.sh/chart: superblocks-agent-2.33.0
+         app.kubernetes.io/version: "v1.16.0"
          app.kubernetes.io/managed-by: Helm
...
            {}
-         image: "ghcr.io/superblocksteam/agent:v1.9.0"
+         image: "ghcr.io/superblocksteam/agent:v1.16.0"
          imagePullPolicy: IfNotPresent
...
superblocks, superblocks-grpc, Ingress (networking.k8s.io) has been added:
-
+ # Source: superblocks-agent/templates/ingress.yaml
+ apiVersion: networking.k8s.io/v1
+ kind: Ingress
+ metadata:
+   name: superblocks-grpc
+   labels:
+     helm.sh/chart: superblocks-agent-2.33.0
+     app.kubernetes.io/version: "v1.16.0"
+     app.kubernetes.io/managed-by: Helm
+   annotations:
+     nginx.ingress.kubernetes.io/backend-protocol: GRPC
+     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-southeast-2:1234:certificate/1234
+     alb.ingress.kubernetes.io/group.name: my-alb
+     alb.ingress.kubernetes.io/group.order: "0"
+     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+     alb.ingress.kubernetes.io/scheme: internet-facing
+     alb.ingress.kubernetes.io/target-type: ip
+     external-dns.alpha.kubernetes.io/hostname: my.host
+ spec:
+   ingressClassName: alb
+   rules:
+     - host:  "my.host"
+       http:
+         paths:
+           - path: /grpc.reflection.v1.ServerReflection
+             pathType: Prefix
+             backend:
+               service:
+                 name: superblocks
+                 port:
+                   number: 8081
+           - path: /grpc.reflection.v1alpha.ServerReflection
+             pathType: Prefix
+             backend:
+               service:
+                 name: superblocks
+                 port:
+                   number: 8081
+           - path: /api.v1.ExecutorService
+             pathType: Prefix
+             backend:
+               service:
+                 name: superblocks
+                 port:
+                   number: 8081
```

# Solution

