### PR TITLE
Fix `yamlfmt` Errors in Helm Chart

### DIFF
--- a/helm/agent/Chart.yaml
+++ b/helm/agent/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v2
 appVersion: v1.17.0
 description: A Helm chart for the Superblocks On-Prem Agent


### PR DESCRIPTION
This addresses the failing `yamlfmt` check in the default github actions run:
```
- hook id: yamlfmt
- files were modified by this hook
pre-commit hook(s) made changes.
If you are seeing this message in CI, reproduce locally with: `pre-commit run --all-files`.
To run `pre-commit` as part of git workflow, use `pre-commit install`.
All changes made by hooks:
diff --git a/helm/agent/Chart.yaml b/helm/agent/Chart.yaml
index 7de5195..5142ec3 100644
--- a/helm/agent/Chart.yaml
+++ b/helm/agent/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v2
 appVersion: v1.17.0
 description: A Helm chart for the Superblocks On-Prem Agent
```
_(see https://github.com/superblocksteam/agent/actions/runs/12435981140/job/34722901608)_