### PR TITLE
[CI] Bump OPA version in chart to v1.18.0

### DIFF
--- a/helm/agent/Chart.yaml
+++ b/helm/agent/Chart.yaml
@@ -1,7 +1,6 @@
----
 apiVersion: v2
-appVersion: v1.17.0
+appVersion: v1.18.0
 description: A Helm chart for the Superblocks On-Prem Agent
 name: superblocks-agent
 type: application
-version: 2.34.0
+version: 2.35.0


### PR DESCRIPTION
Autogenerated PR to bump the App Version in the chart to v1.18.0.